### PR TITLE
Trim whitespace from macro parameters when a new line is detected. Fixes #25

### DIFF
--- a/src/main/java/org/anarres/cpp/MacroTokenSource.java
+++ b/src/main/java/org/anarres/cpp/MacroTokenSource.java
@@ -78,9 +78,13 @@ import static org.anarres.cpp.Token.*;
 
     private void concat(StringBuilder buf, Argument arg) {
         Iterator<Token> it = arg.iterator();
+        boolean newline = false;
         while (it.hasNext()) {
             Token tok = it.next();
-            buf.append(tok.getText());
+            String text = tok.getText();
+            if (text.contains("\n")) newline = true;
+            if (newline) text = text.trim();
+            buf.append(text);
         }
     }
 

--- a/src/test/java/org/anarres/cpp/PreprocessorTest.java
+++ b/src/test/java/org/anarres/cpp/PreprocessorTest.java
@@ -102,6 +102,8 @@ public class PreprocessorTest {
         testInput("#define _CONCAT3(x, y, z) x ## y ## z\n", NL);
         testInput("_CONCAT3(a, b, c)\n", NL, I("abc"));
         testInput("_CONCAT3(A, B, C)\n", NL, I("ABC"));
+        testInput("_CONCAT(test_, inline)\n", NL, I("test_inline"));
+        testInput("_CONCAT(test_, \nnewline)\n", NL, I("test_newline"));
 
         /* Redefinitions, undefinitions. */
         testInput("#define two three\n", NL);


### PR DESCRIPTION
Is close enough to GNU CPP output for my needs that I consider it to fix #25.
It would be nice to see this in a 1.4.8 snapshot asap.
