### PR TITLE
Add Automatic-Module-Name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,3 +54,9 @@ testClasses.dependsOn(processTestVersionResources)
 apply plugin: 'application'
 
 mainClassName = "org.anarres.cpp.Main"
+
+jar {
+  manifest {
+    attributes 'Automatic-Module-Name': 'org.anarres.jcpp'
+  }
+}


### PR DESCRIPTION
This adds an Automatic-Module-Name entry to the produced jar for the
project. The chosen module name is "org.anarres.jcpp".

Fix #35