### PR TITLE
Added support for GCC numeric suffixes and fixed a couple bugs - see details below

### DIFF
--- a/src/main/java/org/anarres/cpp/Feature.java
+++ b/src/main/java/org/anarres/cpp/Feature.java
@@ -37,6 +37,6 @@ public enum Feature {
     /** Supports lexing of objective-C. */
     OBJCSYNTAX,
     INCLUDENEXT,
-    /** Random extensions. */
+    GCC_SUFFIXES, /** Random extensions. */
     PRAGMA_ONCE
 }

--- a/src/main/java/org/anarres/cpp/LexerSource.java
+++ b/src/main/java/org/anarres/cpp/LexerSource.java
@@ -40,6 +40,7 @@ public class LexerSource extends Source {
     private boolean include;
 
     private boolean digraphs;
+    private boolean gccSuffixes;
 
     /* Unread. */
     private int u0, u1;
@@ -60,6 +61,7 @@ public class LexerSource extends Source {
         this.include = false;
 
         this.digraphs = true;
+        this.gccSuffixes = false;
 
         this.ucount = 0;
 
@@ -73,6 +75,7 @@ public class LexerSource extends Source {
     /* pp */ void init(Preprocessor pp) {
         super.init(pp);
         this.digraphs = pp.getFeature(Feature.DIGRAPHS);
+        this.gccSuffixes = pp.getFeature(Feature.GCC_SUFFIXES);
         this.reader.init(pp, this);
     }
 
@@ -512,8 +515,20 @@ public class LexerSource extends Source {
                 text.append((char) d);
                 d = read();
             } else if (d == 'L' || d == 'l') {
-                if ((flags & NumericValue.FF_SIZE) != 0)
-                    warning("Multiple length suffixes after " + text);
+                if ((flags & NumericValue.FF_SIZE) != 0) {
+                    // Added special code for GCC extended numeric types
+                    if (gccSuffixes) {
+                        if ((flags & NumericValue.F_UNSIGNED) != 0) {
+                            flags |= NumericValue.F_GCC_ULONGLONG;   // UL gcc type
+                        } else if ((flags & NumericValue.F_DOUBLE) != 0) {
+                            flags |= NumericValue.F_GCC_DEC128;      // DL gcc type
+                        } else {
+                            warning("Multiple length suffixes after " + text);
+                        }
+                    } else {
+                        warning("Multiple length suffixes after " + text);
+                    }
+                }
                 text.append((char) d);
                 int e = read();
                 if (e == d) {	// Case must match. Ll is Welsh.
@@ -531,14 +546,24 @@ public class LexerSource extends Source {
                 text.append((char) d);
                 d = read();
             } else if (d == 'F' || d == 'f') {
-                if ((flags & NumericValue.FF_SIZE) != 0)
-                    warning("Multiple length suffixes after " + text);
+                if ((flags & NumericValue.FF_SIZE) != 0) {
+                    if (gccSuffixes && ((flags & NumericValue.F_DOUBLE) != 0)) {
+                        flags |= NumericValue.F_GCC_DEC32; // GCC DF suffic
+                    } else {
+                        warning("Multiple length suffixes after " + text);
+                    }
+                }
                 flags |= NumericValue.F_FLOAT;
                 text.append((char) d);
                 d = read();
             } else if (d == 'D' || d == 'd') {
-                if ((flags & NumericValue.FF_SIZE) != 0)
-                    warning("Multiple length suffixes after " + text);
+                if ((flags & NumericValue.FF_SIZE) != 0) {
+                    if (gccSuffixes && ((flags & NumericValue.F_DOUBLE) != 0)) {
+                        flags |= NumericValue.F_GCC_DEC64; // GCC DD suffic
+                    } else {
+                        warning("Multiple length suffixes after " + text);
+                    }
+                }
                 flags |= NumericValue.F_DOUBLE;
                 text.append((char) d);
                 d = read();

--- a/src/main/java/org/anarres/cpp/NumericValue.java
+++ b/src/main/java/org/anarres/cpp/NumericValue.java
@@ -31,8 +31,13 @@ public class NumericValue extends Number {
     public static final int F_LONGLONG = 8;
     public static final int F_FLOAT = 16;
     public static final int F_DOUBLE = 32;
+    public static final int F_GCC_DEC64 = 64; // these are out of order, but I like
+    public static final int F_GCC_DEC128 = 128; // having GCC_DEC128 = 128...
+    public static final int F_GCC_DEC32 = 256;
+    public static final int F_GCC_ULONGLONG = 512;
 
     public static final int FF_SIZE = F_INT | F_LONG | F_LONGLONG | F_FLOAT | F_DOUBLE;
+    public static final int FF_GCC_EXTENDED_SIZES = F_GCC_DEC32 | F_GCC_DEC64 | F_GCC_DEC128 | F_GCC_ULONGLONG;
 
     private final int base;
     private final String integer;


### PR DESCRIPTION
- Added Feature to toggle whether GCC numeric suffixes are active
- Fixed bug when StringLexerSource wasn't init()'ed when added macro
- Fixed bug where macro expansions in the format <foo> and "foo" where
  treated as raw text rather than header/include tokens (code actually
  recognizes the raw text as a header/include and builds it on the fly)