### PR TITLE
Bump sourceCompatibility to 1.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ stdproject {
 		license 'Apache-2.0'
 	}
 
-	sourceCompatibility = 1.5
+	sourceCompatibility = 1.6
 
 dependencies {
 	compile 'com.google.code.findbugs:annotations:3.0.1'


### PR DESCRIPTION
Without this, building fails:

```
$ ./gradlew clean build

> Task :compileJava FAILED
error: Source option 5 is no longer supported. Use 6 or later.
error: Target option 1.5 is no longer supported. Use 1.6 or later.

FAILURE: Build failed with an exception.
[...]
```